### PR TITLE
Feature/rabbit mq RabbitMQ 메세지 교환 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    //RabbitMQ
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/java/com/devit/devitcertificationservice/rabbitMQ/RabbitMqSender.java
+++ b/src/main/java/com/devit/devitcertificationservice/rabbitMQ/RabbitMqSender.java
@@ -1,0 +1,39 @@
+package com.devit.devitcertificationservice.rabbitMQ;
+
+import com.devit.devitcertificationservice.rabbitMQ.dto.UserDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * RabbitMQ에 메시지를 보내는 서비스 클래스
+ */
+@Service
+@Slf4j
+public class RabbitMqSender {
+    // RabbitTemplate 클래스를 사용하면 RabbitMQ로 메시지를 보내고 받을 수 있다.
+    private RabbitTemplate rabbitTemplate;
+
+    @Autowired
+    public RabbitMqSender(RabbitTemplate rabbitTemplate) {
+        this.rabbitTemplate = rabbitTemplate;
+    }
+
+    // yml 파일에서 가져옴
+    // 메시지를 다른 대기열로 라우팅하는 역할을 하는 RabbitMQ 교환을 정의RabbitMQConfig
+    @Value("${spring.rabbitmq.exchange}")
+    private String exchange;
+    // 교환 유형에 따라 메시지를 큐로 라우팅하는 방법을 정의
+    @Value("${spring.rabbitmq.routingkey}")
+    private String routingkey;
+    // yml 파일의 message 를 가져옴
+    @Value("${app.message}")
+    private String message;
+
+    public void send(UserDto userDto) {
+        rabbitTemplate.convertAndSend(exchange, routingkey, userDto);
+        log.info(message);
+    }
+}

--- a/src/main/java/com/devit/devitcertificationservice/rabbitMQ/config/RabbitMQConfig.java
+++ b/src/main/java/com/devit/devitcertificationservice/rabbitMQ/config/RabbitMQConfig.java
@@ -1,0 +1,45 @@
+package com.devit.devitcertificationservice.rabbitMQ.config;
+
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+    // yml 파일의 정보를 가져옴
+    @Value("${spring.rabbitmq.host}")
+    String host;
+    @Value("${spring.rabbitmq.username}")
+    String username;
+    @Value("${spring.rabbitmq.password}")
+    String password;
+
+
+    // host, username(ID), password 정보로 CachingConnectionFactory 를 초기화
+    @Bean
+    CachingConnectionFactory connectionFactory() {
+        CachingConnectionFactory cachingConnectionFactory = new CachingConnectionFactory(host);
+        cachingConnectionFactory.setUsername(username);
+        cachingConnectionFactory.setPassword(password);
+        return cachingConnectionFactory;
+    }
+
+    // JSON 형식으로 메시지를 보냄
+    @Bean
+    public MessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    // RabbitTemplate 를 생성
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        final RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(jsonMessageConverter());
+        return rabbitTemplate;
+    }
+}

--- a/src/main/java/com/devit/devitcertificationservice/rabbitMQ/dto/UserDto.java
+++ b/src/main/java/com/devit/devitcertificationservice/rabbitMQ/dto/UserDto.java
@@ -1,0 +1,38 @@
+package com.devit.devitcertificationservice.rabbitMQ.dto;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+import org.springframework.stereotype.Component;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+/**
+ * 회원가입 후 메시지로 교환할 객체의 도메인 클래스.
+ */
+@Component
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+// @JsonIdentityInfo 어노테이션은 직렬화/역직렬화 중에 개체 ID가 사용됨을 나타내는 데 사용
+@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@id", scope = UserDto.class)
+public class UserDto implements Serializable {
+    @ApiModelProperty(example = "회원 이메일")
+    private String email;
+    @ApiModelProperty(example = "회원 이름")
+    private String name;
+    @ApiModelProperty(example = "회원 uuid (토큰 통신에 사용 될)")
+    private UUID uuid;
+
+    @Override
+    public String toString() {
+        return "User{" +
+                "email='" + email + '\'' +
+                ", name='" + name + '\'' +
+                ", uuid='" + uuid + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/devit/devitcertificationservice/user/sevice/UserService.java
+++ b/src/main/java/com/devit/devitcertificationservice/user/sevice/UserService.java
@@ -4,6 +4,8 @@ import com.devit.devitcertificationservice.auth.dto.TokenDto;
 import com.devit.devitcertificationservice.auth.service.AuthService;
 import com.devit.devitcertificationservice.auth.util.CookieUtil;
 import com.devit.devitcertificationservice.auth.util.token.AuthToken;
+import com.devit.devitcertificationservice.rabbitMQ.RabbitMqSender;
+import com.devit.devitcertificationservice.rabbitMQ.dto.UserDto;
 import com.devit.devitcertificationservice.user.dto.JoinDto;
 import com.devit.devitcertificationservice.user.entity.Type;
 import com.devit.devitcertificationservice.user.entity.UserCertification;
@@ -25,6 +27,7 @@ public class UserService {
     private final UserCertificationRepository userCertificationRepository;
     private final AuthService authService;
     private final PasswordEncoder passwordEncoder;
+    private final RabbitMqSender rabbitMqSender;
 
     /**
      * 이메일 중복 체크
@@ -55,6 +58,10 @@ public class UserService {
         authService.refreshTokenAddCookie(response, refreshToken.getToken());
 
         userCertificationRepository.save(user);
+
+        UserDto userDto = new UserDto(requestJoinDTO.getEmail(), requestJoinDTO.getName(), uuid);
+
+        rabbitMqSender.send(userDto);
 
         return new TokenDto(accessToken.getToken(), refreshToken.getToken());
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,14 @@ spring:
     show-sql: true
     hibernate:
       ddl-auto: create
+  rabbitmq:
+    host: localhost
+    password: 1234
+    port: 5672
+    username: devit
+    exchange: devit.exchange
+    queue: q.user
+    routingkey: devit.routingkey
 
 #  application:
 #    name: certification-service
@@ -51,3 +59,5 @@ app:
   auth:
     tokenExpiry: 10800000            # 3시간
     refreshTokenExpiry: 604800000    # 7일
+
+  message: Message has been sent Successfully..


### PR DESCRIPTION
인증 서버에서 회원가입 후 성공 시 회원 도메인으로 메세지를 전달하는 로직을 구현하였습니다.

> {
              email='dlekgp04231@naver.com', 
              name='이다혜', 
              uuid='4afa5e08-f530-4e93-baa3-fbcfdf9c9fc7'
}

<img width="1099" alt="스크린샷 2022-06-29 오전 10 50 11" src="https://user-images.githubusercontent.com/84092014/176333768-30190a12-2fda-431a-ad28-9c6a3c151bb8.png">

<img width="1392" alt="스크린샷 2022-06-29 오전 10 49 54" src="https://user-images.githubusercontent.com/84092014/176333746-afbfa803-cde1-4815-b2ef-492a9adf0bed.png">

