### PR TITLE
Feature/social 카카오 로그인 및 회원가입 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
     //RabbitMQ
     implementation 'org.springframework.boot:spring-boot-starter-amqp'
 
+    // https://mvnrepository.com/artifact/org.json/json
+    implementation group: 'org.json', name: 'json', version: '20180813'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/java/com/devit/devitcertificationservice/auth/security/KakaoOAuth2.java
+++ b/src/main/java/com/devit/devitcertificationservice/auth/security/KakaoOAuth2.java
@@ -1,0 +1,93 @@
+package com.devit.devitcertificationservice.auth.security;
+
+import com.devit.devitcertificationservice.user.dto.KakaoUserInfo;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.http.HttpHeaders;
+
+@Component
+public class KakaoOAuth2 {
+    @Value("${kakao.secret}")
+    private String restApiKey;
+
+    public KakaoUserInfo getUserInfo(String authorizedCode) {
+        // 1. 인가코드 -> 액세스 토큰
+        String accessToken = getAccessToken(authorizedCode);
+        // 2. 액세스 토큰 -> 카카오 사용자 정보
+        KakaoUserInfo userInfo = getUserInfoByToken(accessToken);
+
+        return userInfo;
+    }
+
+    /**
+     * 인가 코드를 이용하여 kakao access token 가져오기
+     */
+    private String getAccessToken(String authorizedCode) {
+        // HttpHeader 오브젝트 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HttpBody 오브젝트 생성
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", restApiKey);
+        params.add("redirect_uri", "http://localhost:8000/login");
+        params.add("code", authorizedCode);
+
+        // HttpHeader와 HttpBody를 하나의 오브젝트에 담기
+        RestTemplate rt = new RestTemplate();
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest =
+                new HttpEntity<>(params, headers);
+
+        // Http 요청하기 - Post방식으로 - 그리고 response 변수의 응답 받음.
+        ResponseEntity<String> response = rt.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                kakaoTokenRequest,
+                String.class
+        );
+
+        // JSON -> 액세스 토큰 파싱
+        String tokenJson = response.getBody();
+        JSONObject rjson = new JSONObject(tokenJson);
+        String accessToken = rjson.getString("access_token");
+
+        return accessToken;
+    }
+
+    /**
+     * 카카오 access 토큰으로 카카오 유저 정보 가져오기
+     */
+    private KakaoUserInfo getUserInfoByToken(String accessToken) {
+        // HttpHeader 오브젝트 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HttpHeader와 HttpBody를 하나의 오브젝트에 담기
+        RestTemplate rt = new RestTemplate();
+        HttpEntity<MultiValueMap<String, String>> kakaoProfileRequest = new HttpEntity<>(headers);
+
+        // Http 요청하기 - Post방식으로 - 그리고 response 변수의 응답 받음.
+        ResponseEntity<String> response = rt.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.POST,
+                kakaoProfileRequest,
+                String.class
+        );
+
+        JSONObject body = new JSONObject(response.getBody());
+        Long id = body.getLong("id");
+        String email = body.getJSONObject("kakao_account").getString("email");
+        String nickname = body.getJSONObject("properties").getString("nickname");
+
+        return new KakaoUserInfo(id, email, nickname);
+    }
+}

--- a/src/main/java/com/devit/devitcertificationservice/auth/service/AuthService.java
+++ b/src/main/java/com/devit/devitcertificationservice/auth/service/AuthService.java
@@ -68,19 +68,19 @@ public class AuthService {
     public TokenDto login(HttpServletRequest httpRequest, HttpServletResponse httpResponse, LoginDto requestLoginDTO) {
         Optional<UserCertification> userCertificationOptional = userCertificationRepository.findByLoginId(requestLoginDTO.getEmail());
         if (userCertificationOptional.isEmpty()) {
-            System.out.println("이메일로 회원 못찾음");
             return null;
         }
 
         UserCertification user = userCertificationOptional.get();
 
         if (!passwordEncoder.matches(requestLoginDTO.getPassword(), user.getLoginPassword())) {
-            System.out.println("비밀번호 맞지 않음");
             return null;
         }
 
         AuthToken refreshToken = refreshToken(user);
         AuthToken accessToken = AccessToken(user);
+
+        refreshTokenAddCookie(httpResponse, refreshToken.getToken());
 
         return new TokenDto(accessToken.getToken(), refreshToken.getToken());
     }
@@ -101,7 +101,6 @@ public class AuthService {
 
         String path = "/api/auth/refresh";
 
-        System.out.println(authToken.getToken());
         if (!authToken.validate()) {
             return ResponseDetails.invalidAccessToken(path);
         }

--- a/src/main/java/com/devit/devitcertificationservice/auth/util/CookieUtil.java
+++ b/src/main/java/com/devit/devitcertificationservice/auth/util/CookieUtil.java
@@ -15,9 +15,7 @@ public class CookieUtil {
         Cookie[] cookies = request.getCookies();
 
         if (cookies != null && cookies.length > 0) {
-            System.out.println(cookies);
             for (Cookie cookie : cookies) {
-                System.out.println(cookie.getName());
                 if (name.equals(cookie.getName())) {
                     return Optional.of(cookie);
                 }

--- a/src/main/java/com/devit/devitcertificationservice/user/controller/UserController.java
+++ b/src/main/java/com/devit/devitcertificationservice/user/controller/UserController.java
@@ -6,13 +6,10 @@ import com.devit.devitcertificationservice.user.dto.JoinDto;
 import com.devit.devitcertificationservice.user.entity.Type;
 import com.devit.devitcertificationservice.user.sevice.UserService;
 import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -41,5 +38,18 @@ public class UserController {
         Boolean duplicate = userService.duplicateCheck(requestObject);
         ResponseDetails responseDetails = ResponseDetails.success(duplicate, "/api/auth/duplicate-check");
         return new ResponseEntity<>(responseDetails, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/api/auth/kakao/login")
+    public ResponseEntity<?> kakaoLogin(@RequestParam String code, HttpServletResponse response){
+        // authorizedCode: 카카오 서버로부터 받은 인가 코드
+        TokenDto token = userService.kakao(code, response);
+        ResponseDetails responseDetails;
+        if (token == null) {
+            responseDetails = ResponseDetails.fail("토큰 발급에 실패했습니다.", "/api/auth/kakao/login");
+            return new ResponseEntity<>(responseDetails, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        responseDetails = ResponseDetails.success(token, "/api/auth/kakao/login");
+        return new ResponseEntity<>(responseDetails, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/devit/devitcertificationservice/user/dto/KakaoUserInfo.java
+++ b/src/main/java/com/devit/devitcertificationservice/user/dto/KakaoUserInfo.java
@@ -1,0 +1,12 @@
+package com.devit.devitcertificationservice.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class KakaoUserInfo {
+    Long id;
+    String email;
+    String nickname;
+}

--- a/src/main/java/com/devit/devitcertificationservice/user/entity/Type.java
+++ b/src/main/java/com/devit/devitcertificationservice/user/entity/Type.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 @AllArgsConstructor
 public enum Type {
     GENERAL("GENERAL", "일반 가입 회원"),
-    SOCIAL("ADMIN", "소셜 가입 회원");
+    SOCIAL("SOCIAL", "소셜 가입 회원");
 
     private final String code;
     private final String displayName;

--- a/src/main/java/com/devit/devitcertificationservice/user/sevice/UserService.java
+++ b/src/main/java/com/devit/devitcertificationservice/user/sevice/UserService.java
@@ -1,16 +1,23 @@
 package com.devit.devitcertificationservice.user.sevice;
 
 import com.devit.devitcertificationservice.auth.dto.TokenDto;
+import com.devit.devitcertificationservice.auth.security.KakaoOAuth2;
 import com.devit.devitcertificationservice.auth.service.AuthService;
 import com.devit.devitcertificationservice.auth.util.CookieUtil;
 import com.devit.devitcertificationservice.auth.util.token.AuthToken;
 import com.devit.devitcertificationservice.rabbitMQ.RabbitMqSender;
 import com.devit.devitcertificationservice.rabbitMQ.dto.UserDto;
 import com.devit.devitcertificationservice.user.dto.JoinDto;
+import com.devit.devitcertificationservice.user.dto.KakaoUserInfo;
+import com.devit.devitcertificationservice.user.entity.Role;
 import com.devit.devitcertificationservice.user.entity.Type;
 import com.devit.devitcertificationservice.user.entity.UserCertification;
 import com.devit.devitcertificationservice.user.repository.UserCertificationRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,11 +35,16 @@ public class UserService {
     private final AuthService authService;
     private final PasswordEncoder passwordEncoder;
     private final RabbitMqSender rabbitMqSender;
+    private final KakaoOAuth2 kakaoOAuth2;
+
+    @Value("${kakao.adminToken}")
+    private String ADMIN_TOKEN;
+
 
     /**
      * 이메일 중복 체크
      */
-    public boolean emailDuplicate(String email){
+    public boolean emailDuplicate(String email) {
         Optional<UserCertification> user = userCertificationRepository.findByLoginId(email);
         return user.isPresent();
     }
@@ -46,7 +58,7 @@ public class UserService {
 
         UserCertification user = new UserCertification(requestJoinDTO, general, uuid);
         // 이메일이 중복되는 경우
-        if(emailDuplicate(requestJoinDTO.getEmail())){
+        if (emailDuplicate(requestJoinDTO.getEmail())) {
             return null;
         }
 
@@ -72,5 +84,63 @@ public class UserService {
     public Boolean duplicateCheck(Map<String, String> requestObject) {
         String email = requestObject.get("email");
         return emailDuplicate(email);
+    }
+
+    /**
+     * 카카오 로그인 시 DB에 회원 정보가 있다면 토큰 발급
+     */
+    public TokenDto getToken(UserCertification user, HttpServletResponse response) {
+        // refresh token 발급 및 쿠키에 저장
+        AuthToken refreshToken = authService.refreshToken(user);
+        user.updateRefreshToken(refreshToken.getToken());
+        authService.refreshTokenAddCookie(response, refreshToken.getToken());
+
+        // access token 발급
+        AuthToken accessToken = authService.AccessToken(user);
+
+        return new TokenDto(accessToken.getToken(), refreshToken.getToken());
+    }
+
+    /**
+     * 카카오 로그인 시 DB에 회원 정보가 있다면 비밀번호 체크 로직 실행
+     */
+    public TokenDto kakaoLogin(KakaoUserInfo userInfo, UserCertification user, HttpServletResponse response) {
+        Long kakaoId = userInfo.getId();
+        // 패스워드를 카카오 Id + ADMIN TOKEN 로 지정
+        String password = kakaoId + ADMIN_TOKEN;
+        if (!passwordEncoder.matches(password, user.getLoginPassword())) {
+            return null;
+        }
+        return getToken(user, response);
+    }
+
+    /**
+     * 카카오 로그인 시 DB에 회원 정보가 없다면 회원가입 로직 실행
+     */
+    public TokenDto kakaoJoin(KakaoUserInfo userInfo, HttpServletResponse response) {
+        Long kakaoId = userInfo.getId();
+        // 패스워드를 카카오 Id + ADMIN TOKEN 로 지정
+        String password = kakaoId + ADMIN_TOKEN;
+        JoinDto joinDto = new JoinDto(userInfo.getEmail(), password, userInfo.getNickname(), "GENERAL");
+        return join(response, joinDto, Type.valueOf("SOCIAL"));
+    }
+
+    /**
+     * 프론트에서 카카오 로그인 클릭 시 실행되는 서비스 로직
+     */
+    public TokenDto kakao(String authorizedCode, HttpServletResponse response) {
+        // 카카오 OAuth2 를 통해 카카오 사용자 정보 조회
+        KakaoUserInfo userInfo = kakaoOAuth2.getUserInfo(authorizedCode);
+
+        // 이메일 중복 체크 진행 → 중복이라면 이미 가입된 유저임
+        Optional<UserCertification> user = userCertificationRepository.findByLoginId(userInfo.getEmail());
+        TokenDto token;
+        if (user.isPresent()) {
+            // 이미 존재하는 회원이면 토큰 발급
+            token = kakaoLogin(userInfo, user.get(), response);
+        } else {
+            token = kakaoJoin(userInfo, response);
+        }
+        return token;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,7 +44,7 @@ spring:
 
 
 cors:
-  allowed-origins: http://localhost:8080
+  allowed-origins: http://localhost:8000
   allowed-methods: GET,POST,PUT,DELETE,OPTIONS
   allowed-headers: \*
   exposed-headers: Set-Cookie
@@ -52,12 +52,16 @@ cors:
 
   # jwt secret key
 jwt:
-  secret: '8sknjlONPDTBqo39D4HLNqsQFfRcEdKCETOds'
+  secret: '50g/NGsxw15SwkKw8f+fxuXw6hBrEVYXCgJwyzItp8I='
 
-  # secret Key
 app:
   auth:
     tokenExpiry: 10800000            # 3시간
     refreshTokenExpiry: 604800000    # 7일
 
   message: Message has been sent Successfully..
+
+# kakao 로그인 REST API 키
+kakao:
+  secret: 9988be1384b9177a905aa0f6ab1a0d66
+  adminToken: ipq2DcpH7qjFmT3HqfQfpApuxWA=


### PR DESCRIPTION
카카오 로그인 및 회원가입을 구현하였습니다.

로직
1. 프론트 카카오 로그인 버튼 클릭
2. 카카오측으로부터 kakao authorizedCode 를 "프론트가" 받음
3. 프론트는 authorizedCode 를 이용하여 카카오 로그인 API 호출 (DevIT 서버)
4. 서버는 해당 코드를 통해 카카오로 유저 정보를 요청하고 받아온 유저 정보로 DB 탐색
5. DB에 데이터가 있다면 token 발급
6. DB에 데이터가 없다면 DB에 저장하고 메세지큐로 회원 도메인에게 알림 & token 발급